### PR TITLE
modify 'UPDATE DATASOURCE' to preserve existing metadata

### DIFF
--- a/octopus-core/src/main/antlr4/kr/co/bitnine/octopus/sql/OctopusSql.g4
+++ b/octopus-core/src/main/antlr4/kr/co/bitnine/octopus/sql/OctopusSql.g4
@@ -51,7 +51,13 @@ addDataSourceClause
     ;
 
 updateDataSourceClause
-    : K_UPDATE K_DATASOURCE dataSourceName
+    : K_UPDATE K_DATASOURCE updateTargets
+    ;
+
+updateTargets
+    : dataSourceName                                    # UpdateDataSource
+    | dataSourceName '.' schemaPattern                  # UpdateSchemas
+    | dataSourceName '.' schemaName '.' tablePattern    # UpdateTables
     ;
 
 dropDataSourceClause

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/engine/QueryEngine.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/engine/QueryEngine.java
@@ -386,12 +386,22 @@ public class QueryEngine extends AbstractQueryProcessor
         }
 
         @Override
-        public void updateDataSource(String dataSourceName) throws Exception
+        public void updateDataSource(OctopusSqlCommentTarget target) throws Exception
         {
             checkSystemPrivilegeThrow(SystemPrivilege.ALTER_SYSTEM);
-            schemaManager.dropDataSource(dataSourceName);
-            MetaDataSource dataSource = metaContext.updateJdbcDataSource(dataSourceName);
-            schemaManager.addDataSource(dataSource);
+            switch (target.type) {
+                case DATASOURCE:
+                    schemaManager.dropDataSource(target.dataSource);
+                    MetaDataSource dataSource = metaContext.updateJdbcDataSource(target.dataSource);
+                    schemaManager.addDataSource(dataSource);
+                    break;
+                case SCHEMA:
+                    /* TODO */
+                    break;
+                case TABLE:
+                    /* TODO */
+                    break;
+            }
         }
 
         @Override

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/sql/OctopusSql.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/sql/OctopusSql.java
@@ -64,10 +64,27 @@ public final class OctopusSql
         }
 
         @Override
-        public void exitUpdateDataSourceClause(OctopusSqlParser.UpdateDataSourceClauseContext ctx)
+        public void exitUpdateDataSource(OctopusSqlParser.UpdateDataSourceContext ctx)
         {
             String dataSourceName = ctx.dataSourceName().getText();
             commands.add(new OctopusSqlUpdateDataSource(dataSourceName));
+        }
+
+        @Override
+        public void exitUpdateSchemas(OctopusSqlParser.UpdateSchemasContext ctx)
+        {
+            String dataSourceName = ctx.dataSourceName() == null ? null : ctx.dataSourceName().getText();
+            String schemaPattern = ctx.schemaPattern() == null ? null : ctx.schemaPattern().getText();
+            commands.add(new OctopusSqlUpdateDataSource(dataSourceName, schemaPattern));
+        }
+
+        @Override
+        public void exitUpdateTables(OctopusSqlParser.UpdateTablesContext ctx)
+        {
+            String dataSourceName = ctx.dataSourceName() == null ? null : ctx.dataSourceName().getText();
+            String schemaName = ctx.schemaName() == null ? null : ctx.schemaName().getText();
+            String tablePattern = ctx.tablePattern() == null ? null : ctx.tablePattern().getText();
+            commands.add(new OctopusSqlUpdateDataSource(dataSourceName, schemaName, tablePattern));
         }
 
         @Override
@@ -455,7 +472,7 @@ public final class OctopusSql
                 break;
             case UPDATE_DATASOURCE:
                 OctopusSqlUpdateDataSource updateDataSource = (OctopusSqlUpdateDataSource) command;
-                runner.updateDataSource(updateDataSource.getDataSourceName());
+                runner.updateDataSource(updateDataSource.getTarget());
                 break;
             case DROP_DATASOURCE:
                 OctopusSqlDropDataSource dropDataSource = (OctopusSqlDropDataSource) command;

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/sql/OctopusSqlRunner.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/sql/OctopusSqlRunner.java
@@ -23,7 +23,7 @@ import java.util.List;
 public interface OctopusSqlRunner
 {
     void addDataSource(String dataSourceName, String jdbcConnectionString) throws Exception;
-    void updateDataSource(String dataSourceName) throws Exception;
+    void updateDataSource(OctopusSqlCommentTarget target) throws Exception;
     void dropDataSource(String dataSourceName) throws Exception;
     void createUser(String name, String password) throws Exception;
     void alterUser(String name, String password, String oldPassword) throws Exception;

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/sql/OctopusSqlUpdateDataSource.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/sql/OctopusSqlUpdateDataSource.java
@@ -16,16 +16,35 @@ package kr.co.bitnine.octopus.sql;
 
 class OctopusSqlUpdateDataSource extends OctopusSqlCommand
 {
-    private final String dataSourceName;
+    private final OctopusSqlCommentTarget target;
 
     OctopusSqlUpdateDataSource(String dataSourceName)
     {
-        this.dataSourceName = dataSourceName;
+        target = new OctopusSqlCommentTarget();
+        target.type = OctopusSqlCommentTarget.Type.DATASOURCE;
+        target.dataSource = dataSourceName;
     }
 
-    String getDataSourceName()
+    OctopusSqlUpdateDataSource(String dataSourceName, String schemaPattern)
     {
-        return dataSourceName;
+        target = new OctopusSqlCommentTarget();
+        target.type = OctopusSqlCommentTarget.Type.SCHEMA;
+        target.dataSource = dataSourceName;
+        target.schema = schemaPattern;
+    }
+
+    OctopusSqlUpdateDataSource(String dataSourceName, String schemaName, String tablePattern)
+    {
+        target = new OctopusSqlCommentTarget();
+        target.type = OctopusSqlCommentTarget.Type.TABLE;
+        target.dataSource = dataSourceName;
+        target.schema = schemaName;
+        target.table = tablePattern;
+    }
+
+    OctopusSqlCommentTarget getTarget()
+    {
+        return this.target;
     }
 
     @Override

--- a/octopus-core/src/test/java/kr/co/bitnine/octopus/sql/OctopusSqlTest.java
+++ b/octopus-core/src/test/java/kr/co/bitnine/octopus/sql/OctopusSqlTest.java
@@ -38,9 +38,9 @@ public class OctopusSqlTest
             }
 
             @Override
-            public void updateDataSource(String dataSourceName) throws Exception
+            public void updateDataSource(OctopusSqlCommentTarget target) throws Exception
             {
-                System.out.println("UPDATE DATASOURCE name=" + dataSourceName);
+                System.out.println("UPDATE DATASOURCE name=" + target.dataSource);
             }
 
             @Override


### PR DESCRIPTION
I modified the implementation of 'UPDATE DATASOURCE'.
Previous version has bugs that existing metadata (e.g., comment, category) would disappear after 'update datasource'.
