### PR TITLE
implement Calcite JDBC adapter in Octopus. 

### DIFF
--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/engine/CursorDdl.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/engine/CursorDdl.java
@@ -25,8 +25,12 @@ import kr.co.bitnine.octopus.sql.OctopusSql;
 import kr.co.bitnine.octopus.sql.OctopusSqlCommand;
 import kr.co.bitnine.octopus.sql.OctopusSqlRunner;
 import kr.co.bitnine.octopus.sql.TupleSetSql;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 public final class CursorDdl extends Portal {
+    private static final Log LOG = LogFactory.getLog(QueryEngine.class);
     private final OctopusSqlRunner sqlRunner;
 
     CursorDdl(CachedStatement cachedStatement, String name,
@@ -54,6 +58,7 @@ public final class CursorDdl extends Portal {
         } catch (PostgresException e) {
             throw e;
         } catch (Exception e) {
+            LOG.info(ExceptionUtils.getStackTrace(e));
             PostgresErrorData edata = new PostgresErrorData(
                     PostgresSeverity.ERROR,
                     "failed to run DDL - " + e.getMessage());

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/OctopusDataSource.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/OctopusDataSource.java
@@ -14,25 +14,22 @@
 
 package kr.co.bitnine.octopus.schema;
 
-import com.google.common.collect.ImmutableMap;
 import kr.co.bitnine.octopus.meta.model.MetaDataSource;
-import kr.co.bitnine.octopus.meta.model.MetaSchema;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.impl.AbstractSchema;
-
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
-public final class OctopusDataSource extends AbstractSchema {
-    private final String name;
-    private final ImmutableMap<String, Schema> subSchemaMap;
+public class OctopusDataSource extends AbstractSchema {
+    private static final Log LOG = LogFactory.getLog(OctopusDataSource.class);
+
+    protected final String name;
+    protected ImmutableMap<String, Schema> subSchemaMap;
 
     public OctopusDataSource(MetaDataSource metaDataSource) {
         name = metaDataSource.getName();
-
-        ImmutableMap.Builder<String, Schema> builder = ImmutableMap.builder();
-        for (MetaSchema metaSchema : metaDataSource.getSchemas())
-            builder.put(metaSchema.getName(), new OctopusSchema(metaSchema, this));
-        subSchemaMap = builder.build();
     }
 
     public String getName() {
@@ -46,6 +43,7 @@ public final class OctopusDataSource extends AbstractSchema {
 
     @Override
     protected Map<String, Schema> getSubSchemaMap() {
+        LOG.debug("OctopusDataSource getSubSchemaMap called. subSchemaMapSize: " + subSchemaMap.size());
         return subSchemaMap;
     }
 }

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/OctopusSchema.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/OctopusSchema.java
@@ -21,20 +21,18 @@ import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 
 import java.util.Map;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
-public final class OctopusSchema extends AbstractSchema {
+public class OctopusSchema extends AbstractSchema {
+    private static final Log LOG = LogFactory.getLog(OctopusSchema.class);
+
     private final String name;
-    private final ImmutableMap<String, Table> tableMap;
     private final OctopusDataSource dataSource;
+    protected ImmutableMap<String, Table> tableMap;
 
     public OctopusSchema(MetaSchema metaSchema, OctopusDataSource dataSource) {
         name = metaSchema.getName();
-
-        ImmutableMap.Builder<String, Table> builder = ImmutableMap.builder();
-        for (MetaTable metaTable : metaSchema.getTables())
-            builder.put(metaTable.getName(), new OctopusTable(metaTable, this));
-        tableMap = builder.build();
-
         this.dataSource = dataSource;
     }
 
@@ -49,6 +47,7 @@ public final class OctopusSchema extends AbstractSchema {
 
     @Override
     protected Map<String, Table> getTableMap() {
+        LOG.debug("OctopusSchema getTableMap called. tableMapSize: " + tableMap.size());
         return tableMap;
     }
 

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/OctopusTable.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/OctopusTable.java
@@ -16,23 +16,27 @@ package kr.co.bitnine.octopus.schema;
 
 import kr.co.bitnine.octopus.meta.model.MetaColumn;
 import kr.co.bitnine.octopus.meta.model.MetaTable;
+import org.apache.calcite.adapter.java.AbstractQueryableTable;
+import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.linq4j.Queryable;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeImpl;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.schema.Schema;
-import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-public final class OctopusTable extends AbstractTable {
-    private final String name;
+public class OctopusTable extends AbstractQueryableTable {
     private Schema.TableType tableType;
-    private final RelProtoDataType protoRowType;
-    private final OctopusSchema schema;
+    protected RelProtoDataType protoRowType;
+    protected final OctopusSchema schema;
+    protected final String name;
 
     public OctopusTable(MetaTable metaTable, OctopusSchema schema) {
+        super(Object[].class);
         name = metaTable.getName();
 
         try {
@@ -75,5 +79,10 @@ public final class OctopusTable extends AbstractTable {
 
     public OctopusSchema getSchema() {
         return schema;
+    }
+
+    @Override
+    public <T> Queryable<T> asQueryable(QueryProvider queryProvider, SchemaPlus schema, String tableName) {
+        return null;
     }
 }

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/SchemaManager.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/SchemaManager.java
@@ -22,6 +22,9 @@ import kr.co.bitnine.octopus.postgres.utils.PostgresErrorData;
 import kr.co.bitnine.octopus.postgres.utils.PostgresException;
 import kr.co.bitnine.octopus.postgres.utils.PostgresSQLState;
 import kr.co.bitnine.octopus.postgres.utils.PostgresSeverity;
+import kr.co.bitnine.octopus.schema.jdbc.JdbcUtils;
+import kr.co.bitnine.octopus.schema.jdbc.OctopusJdbcDataSource;
+import kr.co.bitnine.octopus.schema.jdbc.OctopusJdbcSchema;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
@@ -76,6 +79,15 @@ public final class SchemaManager extends AbstractService {
         super.serviceStart();
     }
 
+    @Override
+    protected void serviceStop() throws Exception {
+        super.serviceStop();
+    }
+
+    public void resetDataSourcePool() throws Exception {
+        JdbcUtils.DataSourcePool.INSTANCE.closeAll();
+    }
+
     private void loadMeta() throws MetaException {
         MetaContext mc = metaStore.getMetaContext();
 
@@ -86,7 +98,9 @@ public final class SchemaManager extends AbstractService {
     }
 
     public void addDataSource(MetaDataSource metaDataSource) {
-        OctopusDataSource octopusDataSource = new OctopusDataSource(metaDataSource);
+        // TODO: create DataSource classes according to the type of the DataSource (eg. JDBC, Catalog, MetaModel, ...)
+        LOG.info("Add DataSource to Calcite Schema. DataSourceName: " + metaDataSource.getName());
+        OctopusDataSource octopusDataSource = new OctopusJdbcDataSource(rootSchema, metaDataSource);
         addDataSource(octopusDataSource);
     }
 

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/JdbcImplementor.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/JdbcImplementor.java
@@ -1,0 +1,529 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kr.co.bitnine.octopus.schema.jdbc;
+
+import com.google.common.collect.ImmutableList;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexLocalRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlBinaryOperator;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlJoin;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlSelectKeyword;
+import org.apache.calcite.sql.SqlSetOperator;
+import org.apache.calcite.sql.fun.SqlCase;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.BasicSqlType;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+
+/**
+ * State for generating a SQL statement.
+ */
+public class JdbcImplementor {
+  public static final SqlParserPos POS = SqlParserPos.ZERO;
+
+  final SqlDialect dialect;
+  private final Set<String> aliasSet = new LinkedHashSet<String>();
+
+  public JdbcImplementor(SqlDialect dialect, JavaTypeFactory typeFactory) {
+    this.dialect = dialect;
+    Util.discard(typeFactory);
+  }
+
+  /** Creates a result based on a single relational expression. */
+  public Result result(SqlNode node, Collection<Clause> clauses, RelNode rel) {
+    final String alias2 = SqlValidatorUtil.getAlias(node, -1);
+    final String alias3 = alias2 != null ? alias2 : "t";
+    final String alias4 =
+        SqlValidatorUtil.uniquify(
+            alias3, aliasSet, SqlValidatorUtil.EXPR_SUGGESTER);
+    final String alias5 = alias2 == null || !alias2.equals(alias4) ? alias4
+        : null;
+    return new Result(node, clauses, alias5,
+        Collections.singletonList(Pair.of(alias4, rel.getRowType())));
+  }
+
+  /** Creates a result based on a join. (Each join could contain one or more
+   * relational expressions.) */
+  public Result result(SqlNode join, Result leftResult, Result rightResult) {
+    final List<Pair<String, RelDataType>> list =
+        new ArrayList<Pair<String, RelDataType>>();
+    list.addAll(leftResult.aliases);
+    list.addAll(rightResult.aliases);
+    return new Result(join, Expressions.list(Clause.FROM), null, list);
+  }
+
+  /** Wraps a node in a SELECT statement that has no clauses:
+   *  "SELECT ... FROM (node)". */
+  SqlSelect wrapSelect(SqlNode node) {
+    assert node instanceof SqlJoin
+        || node instanceof SqlIdentifier
+        || node instanceof SqlCall
+        && (((SqlCall) node).getOperator() instanceof SqlSetOperator
+        || ((SqlCall) node).getOperator() == SqlStdOperatorTable.AS)
+        : node;
+    return new SqlSelect(POS, SqlNodeList.EMPTY, null, node, null, null, null,
+        SqlNodeList.EMPTY, null, null, null);
+  }
+
+  public Result visitChild(int i, RelNode e) {
+    return ((JdbcRel) e).implement(this);
+  }
+
+  /** Context for translating a {@link org.apache.calcite.rex.RexNode} expression (within a
+   * {@link org.apache.calcite.rel.RelNode}) into a {@link org.apache.calcite.sql.SqlNode} expression (within a SQL parse
+   * tree). */
+  public abstract class Context {
+    private final int fieldCount;
+
+    protected Context(int fieldCount) {
+      this.fieldCount = fieldCount;
+    }
+
+    public abstract SqlNode field(int ordinal);
+
+    /** Converts an expression from {@link org.apache.calcite.rex.RexNode} to {@link org.apache.calcite.sql.SqlNode}
+     * format. */
+    SqlNode toSql(RexProgram program, RexNode rex) {
+      switch (rex.getKind()) {
+      case LOCAL_REF:
+        final int index = ((RexLocalRef) rex).getIndex();
+        return toSql(program, program.getExprList().get(index));
+
+      case INPUT_REF:
+        return field(((RexInputRef) rex).getIndex());
+
+      case LITERAL:
+        final RexLiteral literal = (RexLiteral) rex;
+        if (literal.getTypeName() == SqlTypeName.SYMBOL) {
+          final SqlLiteral.SqlSymbol symbol =
+              (SqlLiteral.SqlSymbol) literal.getValue();
+          return SqlLiteral.createSymbol(symbol, POS);
+        }
+        switch (literal.getTypeName().getFamily()) {
+        case CHARACTER:
+          return SqlLiteral.createCharString((String) literal.getValue2(), POS);
+        case NUMERIC:
+        case EXACT_NUMERIC:
+          return SqlLiteral.createExactNumeric(literal.getValue().toString(),
+              POS);
+        case APPROXIMATE_NUMERIC:
+          return SqlLiteral.createApproxNumeric(
+              literal.getValue().toString(), POS);
+        case BOOLEAN:
+          return SqlLiteral.createBoolean((Boolean) literal.getValue(), POS);
+        case DATE:
+          return SqlLiteral.createDate((Calendar) literal.getValue(), POS);
+        case TIME:
+          return SqlLiteral.createTime((Calendar) literal.getValue(),
+              literal.getType().getPrecision(), POS);
+        case TIMESTAMP:
+          return SqlLiteral.createTimestamp((Calendar) literal.getValue(),
+              literal.getType().getPrecision(), POS);
+        case ANY:
+        case NULL:
+          switch (literal.getTypeName()) {
+          case NULL:
+            return SqlLiteral.createNull(POS);
+          // fall through
+          }
+        default:
+          throw new AssertionError(literal + ": " + literal.getTypeName());
+        }
+      case CASE:
+        final RexCall caseCall = (RexCall) rex;
+        final List<SqlNode> caseNodeList =
+            toSql(program, caseCall.getOperands());
+        final SqlNode valueNode;
+        final List<SqlNode> whenList = Expressions.list();
+        final List<SqlNode> thenList = Expressions.list();
+        final SqlNode elseNode;
+        if (caseNodeList.size() % 2 == 0) {
+          // switched:
+          //   "case x when v1 then t1 when v2 then t2 ... else e end"
+          valueNode = caseNodeList.get(0);
+          for (int i = 1; i < caseNodeList.size() - 1; i += 2) {
+            whenList.add(caseNodeList.get(i));
+            thenList.add(caseNodeList.get(i + 1));
+          }
+        } else {
+          // other: "case when w1 then t1 when w2 then t2 ... else e end"
+          valueNode = null;
+          for (int i = 0; i < caseNodeList.size() - 1; i += 2) {
+            whenList.add(caseNodeList.get(i));
+            thenList.add(caseNodeList.get(i + 1));
+          }
+        }
+        elseNode = caseNodeList.get(caseNodeList.size() - 1);
+        return new SqlCase(POS, valueNode, new SqlNodeList(whenList, POS),
+            new SqlNodeList(thenList, POS), elseNode);
+
+      default:
+        final RexCall call = (RexCall) rex;
+        final SqlOperator op = call.getOperator();
+        final List<SqlNode> nodeList = toSql(program, call.getOperands());
+        switch (rex.getKind()) {
+        case CAST:
+          nodeList.add(toSql(call.getType()));
+        }
+        if (op instanceof SqlBinaryOperator && nodeList.size() > 2) {
+          // In RexNode trees, OR and AND have any number of children;
+          // SqlCall requires exactly 2. So, convert to a left-deep binary tree.
+          return createLeftCall(op, nodeList);
+        }
+        return op.createCall(new SqlNodeList(nodeList, POS));
+      }
+    }
+
+    private SqlNode createLeftCall(SqlOperator op, List<SqlNode> nodeList) {
+      if (nodeList.size() == 2) {
+        return op.createCall(new SqlNodeList(nodeList, POS));
+      }
+      final List<SqlNode> butLast = Util.skipLast(nodeList);
+      final SqlNode last = nodeList.get(nodeList.size() - 1);
+      final SqlNode call = createLeftCall(op, butLast);
+      return op.createCall(new SqlNodeList(ImmutableList.of(call, last), POS));
+    }
+
+    private SqlNode toSql(RelDataType type) {
+      switch (dialect.getDatabaseProduct()) {
+      case MYSQL:
+        switch (type.getSqlTypeName()) {
+        case VARCHAR:
+          // MySQL doesn't have a VARCHAR type, only CHAR.
+          return new SqlDataTypeSpec(new SqlIdentifier("CHAR", POS),
+              type.getPrecision(), -1, null, null, POS);
+        case INTEGER:
+          return new SqlDataTypeSpec(new SqlIdentifier("_UNSIGNED", POS),
+              type.getPrecision(), -1, null, null, POS);
+        }
+        break;
+      }
+      if (type instanceof BasicSqlType) {
+        return new SqlDataTypeSpec(
+            new SqlIdentifier(type.getSqlTypeName().name(), POS),
+            type.getPrecision(),
+            type.getScale(),
+            type.getCharset() != null
+            && dialect.supportsCharSet()
+                ? type.getCharset().name()
+                : null,
+            null,
+            POS);
+      }
+      throw new AssertionError(type); // TODO: implement
+    }
+
+    private List<SqlNode> toSql(RexProgram program, List<RexNode> operandList) {
+      final List<SqlNode> list = new ArrayList<SqlNode>();
+      for (RexNode rex : operandList) {
+        list.add(toSql(program, rex));
+      }
+      return list;
+    }
+
+    public List<SqlNode> fieldList() {
+      return new AbstractList<SqlNode>() {
+        public SqlNode get(int index) {
+          return field(index);
+        }
+
+        public int size() {
+          return fieldCount;
+        }
+      };
+    }
+
+    /** Converts a call to an aggregate function to an expression. */
+    public SqlNode toSql(AggregateCall aggCall) {
+      SqlOperator op = (SqlAggFunction) aggCall.getAggregation();
+      if (op instanceof SqlSumEmptyIsZeroAggFunction) {
+        op = SqlStdOperatorTable.SUM;
+      }
+      final List<SqlNode> operands = Expressions.list();
+      for (int arg : aggCall.getArgList()) {
+        operands.add(field(arg));
+      }
+      return op.createCall(
+          aggCall.isDistinct() ? SqlSelectKeyword.DISTINCT.symbol(POS) : null,
+          POS, operands.toArray(new SqlNode[operands.size()]));
+    }
+
+    /** Converts a collation to an ORDER BY item. */
+    public SqlNode toSql(RelFieldCollation collation) {
+      SqlNode node = field(collation.getFieldIndex());
+      switch (collation.getDirection()) {
+      case DESCENDING:
+      case STRICTLY_DESCENDING:
+        node = SqlStdOperatorTable.DESC.createCall(POS, node);
+      }
+      switch (collation.nullDirection) {
+      case FIRST:
+        node = SqlStdOperatorTable.NULLS_FIRST.createCall(POS, node);
+        break;
+      case LAST:
+        node = SqlStdOperatorTable.NULLS_LAST.createCall(POS, node);
+        break;
+      }
+      return node;
+    }
+  }
+
+  private static int computeFieldCount(
+      List<Pair<String, RelDataType>> aliases) {
+    int x = 0;
+    for (Pair<String, RelDataType> alias : aliases) {
+      x += alias.right.getFieldCount();
+    }
+    return x;
+  }
+
+  /** Implementation of Context that precedes field references with their
+   * "table alias" based on the current sub-query's FROM clause. */
+  public class AliasContext extends Context {
+    private final boolean qualified;
+    private final List<Pair<String, RelDataType>> aliases;
+
+    public AliasContext(List<Pair<String, RelDataType>> aliases,
+        boolean qualified) {
+      super(computeFieldCount(aliases));
+      this.aliases = aliases;
+      this.qualified = qualified;
+    }
+
+    public SqlNode field(int ordinal) {
+      for (Pair<String, RelDataType> alias : aliases) {
+        final List<RelDataTypeField> fields = alias.right.getFieldList();
+        if (ordinal < fields.size()) {
+          RelDataTypeField field = fields.get(ordinal);
+          return new SqlIdentifier(!qualified
+              ? ImmutableList.of(field.getName())
+              : ImmutableList.of(alias.left, field.getName()),
+              POS);
+        }
+        ordinal -= fields.size();
+      }
+      throw new AssertionError(
+          "field ordinal " + ordinal + " out of range " + aliases);
+    }
+  }
+
+  /** Result of implementing a node. */
+  public class Result {
+    final SqlNode node;
+    private final String neededAlias;
+    private final List<Pair<String, RelDataType>> aliases;
+    final Expressions.FluentList<Clause> clauses;
+
+    private Result(SqlNode node, Collection<Clause> clauses, String neededAlias,
+        List<Pair<String, RelDataType>> aliases) {
+      this.node = node;
+      this.neededAlias = neededAlias;
+      this.aliases = aliases;
+      this.clauses = Expressions.list(clauses);
+    }
+
+    /** Once you have a Result of implementing a child relational expression,
+     * call this method to create a Builder to implement the current relational
+     * expression by adding additional clauses to the SQL query.
+     *
+     * <p>You need to declare which clauses you intend to add. If the clauses
+     * are "later", you can add to the same query. For example, "GROUP BY" comes
+     * after "WHERE". But if they are the same or earlier, this method will
+     * start a new SELECT that wraps the previous result.</p>
+     *
+     * <p>When you have called
+     * {@link Builder#setSelect(org.apache.calcite.sql.SqlNodeList)},
+     * {@link Builder#setWhere(org.apache.calcite.sql.SqlNode)} etc. call
+     * {@link Builder#result(org.apache.calcite.sql.SqlNode, java.util.Collection, org.apache.calcite.rel.RelNode)}
+     * to fix the new query.</p>
+     *
+     * @param rel Relational expression being implemented
+     * @param clauses Clauses that will be generated to implement current
+     *                relational expression
+     * @return A builder
+     */
+    public Builder builder(JdbcRel rel, Clause... clauses) {
+      final Clause maxClause = maxClause();
+      boolean needNew = false;
+      for (Clause clause : clauses) {
+        if (maxClause.ordinal() >= clause.ordinal()) {
+          needNew = true;
+        }
+      }
+      SqlSelect select;
+      Expressions.FluentList<Clause> clauseList = Expressions.list();
+      if (needNew) {
+        select = subSelect();
+      } else {
+        select = asSelect();
+        clauseList.addAll(this.clauses);
+      }
+      clauseList.appendAll(clauses);
+      Context newContext;
+      final SqlNodeList selectList = select.getSelectList();
+      if (selectList != null) {
+        newContext = new Context(selectList.size()) {
+          @Override public SqlNode field(int ordinal) {
+            final SqlNode selectItem = selectList.get(ordinal);
+            switch (selectItem.getKind()) {
+            case AS:
+              return ((SqlCall) selectItem).operand(0);
+            }
+            return selectItem;
+          }
+        };
+      } else {
+        newContext = new AliasContext(aliases, aliases.size() > 1);
+      }
+      return new Builder(rel, clauseList, select, newContext);
+    }
+
+    // make private?
+    public Clause maxClause() {
+      Clause maxClause = null;
+      for (Clause clause : clauses) {
+        if (maxClause == null || clause.ordinal() > maxClause.ordinal()) {
+          maxClause = clause;
+        }
+      }
+      assert maxClause != null;
+      return maxClause;
+    }
+
+    /** Returns a node that can be included in the FROM clause or a JOIN. It has
+     * an alias that is unique within the query. The alias is implicit if it
+     * can be derived using the usual rules (For example, "SELECT * FROM emp" is
+     * equivalent to "SELECT * FROM emp AS emp".) */
+    public SqlNode asFrom() {
+      if (neededAlias != null) {
+        return SqlStdOperatorTable.AS.createCall(POS, node,
+            new SqlIdentifier(neededAlias, POS));
+      }
+      return node;
+    }
+
+    public SqlSelect subSelect() {
+      return wrapSelect(asFrom());
+    }
+
+    /** Converts a non-query node into a SELECT node. Set operators (UNION,
+     * INTERSECT, EXCEPT) remain as is. */
+    SqlSelect asSelect() {
+      if (node instanceof SqlSelect) {
+        return (SqlSelect) node;
+      }
+      return wrapSelect(node);
+    }
+
+    /** Converts a non-query node into a SELECT node. Set operators (UNION,
+     * INTERSECT, EXCEPT) remain as is. */
+    public SqlNode asQuery() {
+      if (node instanceof SqlCall
+          && ((SqlCall) node).getOperator() instanceof SqlSetOperator) {
+        return node;
+      }
+      return asSelect();
+    }
+
+    /** Returns a context that always qualifies identifiers. Useful if the
+     * Context deals with just one arm of a join, yet we wish to generate
+     * a join condition that qualifies column names to disambiguate them. */
+    public Context qualifiedContext() {
+      return new AliasContext(aliases, true);
+    }
+  }
+
+  /** Builder. */
+  public class Builder {
+    private final JdbcRel rel;
+    private final List<Clause> clauses;
+    private final SqlSelect select;
+    public final Context context;
+
+    public Builder(JdbcRel rel, List<Clause> clauses, SqlSelect select,
+        Context context) {
+      this.rel = rel;
+      this.clauses = clauses;
+      this.select = select;
+      this.context = context;
+    }
+
+    public void setSelect(SqlNodeList nodeList) {
+      select.setSelectList(nodeList);
+    }
+
+    public void setWhere(SqlNode node) {
+      assert clauses.contains(Clause.WHERE);
+      select.setWhere(node);
+    }
+
+    public void setGroupBy(SqlNodeList nodeList) {
+      assert clauses.contains(Clause.GROUP_BY);
+      select.setGroupBy(nodeList);
+    }
+
+    public void setOrderBy(SqlNodeList nodeList) {
+      assert clauses.contains(Clause.ORDER_BY);
+      select.setOrderBy(nodeList);
+    }
+
+    public Result result() {
+      return JdbcImplementor.this.result(select, clauses, rel);
+    }
+  }
+
+  /** Clauses in a SQL query. Ordered by evaluation order.
+   * SELECT is set only when there is a NON-TRIVIAL SELECT clause. */
+  enum Clause {
+    FROM, WHERE, GROUP_BY, HAVING, SELECT, SET_OP, ORDER_BY
+  }
+}
+
+// End JdbcImplementor.java

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/JdbcRel.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/JdbcRel.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kr.co.bitnine.octopus.schema.jdbc;
+
+import org.apache.calcite.rel.RelNode;
+
+/**
+ * Relational expression that uses JDBC calling convention.
+ */
+public interface JdbcRel extends RelNode {
+  JdbcImplementor.Result implement(JdbcImplementor implementor);
+}
+
+// End JdbcRel.java

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/JdbcTableScan.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/JdbcTableScan.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kr.co.bitnine.octopus.schema.jdbc;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.calcite.adapter.jdbc.JdbcConvention;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableScan;
+
+/**
+ * Relational expression representing a scan of a table in a JDBC data source.
+ */
+public class JdbcTableScan extends TableScan implements JdbcRel {
+  final OctopusJdbcTable jdbcTable;
+
+  protected JdbcTableScan(RelOptCluster cluster, RelOptTable table, OctopusJdbcTable jdbcTable, JdbcConvention jdbcConvention) {
+    super(cluster, cluster.traitSetOf(jdbcConvention), table);
+    this.jdbcTable = jdbcTable;
+    assert jdbcTable != null;
+  }
+
+  @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    assert inputs.isEmpty();
+    return new JdbcTableScan(
+        getCluster(), table, jdbcTable, (JdbcConvention) getConvention());
+  }
+
+  public JdbcImplementor.Result implement(JdbcImplementor implementor) {
+    return implementor.result(jdbcTable.tableName(),
+        Collections.singletonList(JdbcImplementor.Clause.FROM), this);
+  }
+}
+
+// End JdbcTableScan.java

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/JdbcUtils.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/JdbcUtils.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kr.co.bitnine.octopus.schema.jdbc;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import javax.sql.DataSource;
+import org.apache.calcite.avatica.util.DateTimeUtils;
+import org.apache.calcite.linq4j.function.Function0;
+import org.apache.calcite.linq4j.function.Function1;
+import org.apache.calcite.linq4j.tree.Primitive;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.IntList;
+import org.apache.calcite.util.Pair;
+import org.apache.commons.dbcp.BasicDataSource;
+
+/**
+ * Utilities for the JDBC provider.
+ */
+public final class JdbcUtils {
+  private JdbcUtils() {
+    throw new AssertionError("no instances!");
+  }
+
+  /** Pool of dialects. */
+  public static class DialectPool {
+    final Map<DataSource, SqlDialect> map0 =
+        new IdentityHashMap<DataSource, SqlDialect>();
+    final Map<List, SqlDialect> map = new HashMap<List, SqlDialect>();
+
+    public static final DialectPool INSTANCE = new DialectPool();
+
+    SqlDialect get(DataSource dataSource) {
+      final SqlDialect sqlDialect = map0.get(dataSource);
+      if (sqlDialect != null) {
+        return sqlDialect;
+      }
+      Connection connection = null;
+      try {
+        connection = dataSource.getConnection();
+        DatabaseMetaData metaData = connection.getMetaData();
+        String productName = metaData.getDatabaseProductName();
+        String productVersion = metaData.getDatabaseProductVersion();
+        List key = ImmutableList.of(productName, productVersion);
+        SqlDialect dialect = map.get(key);
+        if (dialect == null) {
+          final SqlDialect.DatabaseProduct product =
+              SqlDialect.getProduct(productName, productVersion);
+          dialect =
+              new SqlDialect(
+                  product,
+                  productName,
+                  metaData.getIdentifierQuoteString());
+          map.put(key, dialect);
+          map0.put(dataSource, dialect);
+        }
+        connection.close();
+        connection = null;
+        return dialect;
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      } finally {
+        if (connection != null) {
+          try {
+            connection.close();
+          } catch (SQLException e) {
+            // ignore
+          }
+        }
+      }
+    }
+  }
+
+  /** Builder that calls {@link java.sql.ResultSet#getObject(int)} for every column,
+   * or {@code getXxx} if the result type is a primitive {@code xxx},
+   * and returns an array of objects for each row. */
+  public static class ObjectArrayRowBuilder implements Function0<Object[]> {
+    private final ResultSet resultSet;
+    private final int columnCount;
+    private final Primitive[] primitives;
+    private final int[] types;
+
+    public ObjectArrayRowBuilder(
+        ResultSet resultSet, Primitive[] primitives, int[] types)
+        throws SQLException {
+      this.resultSet = resultSet;
+      this.primitives = primitives;
+      this.types = types;
+      this.columnCount = resultSet.getMetaData().getColumnCount();
+    }
+
+    public static Function1<ResultSet, Function0<Object[]>> factory(
+        final List<Pair<Primitive, Integer>> list) {
+      return new Function1<ResultSet, Function0<Object[]>>() {
+        public Function0<Object[]> apply(ResultSet resultSet) {
+          try {
+            return new ObjectArrayRowBuilder(
+                resultSet,
+                Pair.left(list).toArray(new Primitive[list.size()]),
+                IntList.toArray(Pair.right(list)));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      };
+    }
+
+    public Object[] apply() {
+      try {
+        final Object[] values = new Object[columnCount];
+        for (int i = 0; i < columnCount; i++) {
+          values[i] = value(i);
+        }
+        return values;
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    /**
+     * Gets a value from a given column in a JDBC result set.
+     *
+     * @param i Ordinal of column (1-based, per JDBC)
+     */
+    private Object value(int i) throws SQLException {
+      // MySQL returns timestamps shifted into local time. Using
+      // getTimestamp(int, Calendar) with a UTC calendar should prevent this,
+      // but does not. So we shift explicitly.
+      switch (types[i]) {
+      case Types.TIMESTAMP:
+        return shift(resultSet.getTimestamp(i + 1));
+      case Types.TIME:
+        return shift(resultSet.getTime(i + 1));
+      case Types.DATE:
+        return shift(resultSet.getDate(i + 1));
+      }
+      return primitives[i].jdbcGet(resultSet, i + 1);
+    }
+
+    private static Timestamp shift(Timestamp v) {
+      if (v == null) {
+        return null;
+      }
+      long time = v.getTime();
+      int offset = TimeZone.getDefault().getOffset(time);
+      return new Timestamp(time + offset);
+    }
+
+    private static Time shift(Time v) {
+      if (v == null) {
+        return null;
+      }
+      long time = v.getTime();
+      int offset = TimeZone.getDefault().getOffset(time);
+      return new Time((time + offset) % DateTimeUtils.MILLIS_PER_DAY);
+    }
+
+    private static Date shift(Date v) {
+      if (v == null) {
+        return null;
+      }
+      long time = v.getTime();
+      int offset = TimeZone.getDefault().getOffset(time);
+      return new Date(time + offset);
+    }
+  }
+
+  /** Ensures that if two data sources have the same definition, they will use
+   * the same object.
+   *
+   * <p>This in turn makes it easier to cache
+   * {@link org.apache.calcite.sql.SqlDialect} objects. Otherwise, each time we
+   * see a new data source, we have to open a connection to find out what
+   * database product and version it is. */
+  public static class DataSourcePool {
+    public static final DataSourcePool INSTANCE = new DataSourcePool();
+
+    private final LoadingCache<List<String>, BasicDataSource> cache =
+        CacheBuilder.newBuilder().softValues().build(
+            new CacheLoader<List<String>, BasicDataSource>() {
+              @Override public BasicDataSource load(List<String> key) {
+                BasicDataSource dataSource = new BasicDataSource();
+                dataSource.setUrl(key.get(0));
+                dataSource.setDriverClassName(key.get(1));
+                return dataSource;
+              }
+            });
+
+    public DataSource get(String url, String driverClassName) {
+      // Get data source objects from a cache, so that we don't have to sniff
+      // out what kind of database they are quite as often.
+      final List<String> key =
+          ImmutableNullableList.of(url, driverClassName);
+      return cache.apply(key);
+    }
+
+    /* This method is for running Unit Tests in Octopus code.
+       There is no synchronization between closeAll() and get().
+     */
+    public void closeAll() throws SQLException {
+      cache.asMap();
+      for (BasicDataSource datasource : cache.asMap().values()) {
+          datasource.close();
+      }
+        cache.invalidateAll();
+    }
+  }
+}
+
+// End JdbcUtils.java

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/OctopusJdbcDataSource.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/OctopusJdbcDataSource.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kr.co.bitnine.octopus.schema.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import javax.sql.DataSource;
+import kr.co.bitnine.octopus.meta.model.MetaDataSource;
+import kr.co.bitnine.octopus.meta.model.MetaSchema;
+import kr.co.bitnine.octopus.schema.OctopusDataSource;
+import org.apache.calcite.adapter.jdbc.JdbcConvention;
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Schemas;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class OctopusJdbcDataSource extends OctopusDataSource {
+    private static final Log LOG = LogFactory.getLog(OctopusJdbcDataSource.class);
+
+    public final SqlDialect dialect;
+    final JdbcConvention convention;
+    final DataSource dataSource;
+
+    public OctopusJdbcDataSource(SchemaPlus parentSchema, MetaDataSource metaDataSource) {
+        super(metaDataSource);
+
+        LOG.debug("create OctopusJdbcDataSource. dataSourceName: " + metaDataSource.getName());
+        dataSource = dataSource(metaDataSource.getConnectionString(), metaDataSource.getDriverName());
+
+        /* TODO: what is this? */
+        final Expression expression =
+                Schemas.subSchemaExpression(parentSchema, name, JdbcSchema.class);
+
+        this.dialect = createDialect(dataSource);
+        this.convention = JdbcConvention.of(dialect, expression, metaDataSource.getName());
+
+        ImmutableMap.Builder<String, Schema> builder = ImmutableMap.builder();
+        for (MetaSchema metaSchema : metaDataSource.getSchemas())
+            builder.put(metaSchema.getName(), new OctopusJdbcSchema(metaSchema, this));
+        subSchemaMap = builder.build();
+    }
+
+    /** Creates a JDBC data source with the given specification. */
+    public static DataSource dataSource(String connectionString, String driverClassName) {
+        return JdbcUtils.DataSourcePool.INSTANCE.get(connectionString, driverClassName);
+    }
+
+    /** Returns a suitable SQL dialect for the given data source. */
+    public static SqlDialect createDialect(DataSource dataSource) {
+        return JdbcUtils.DialectPool.INSTANCE.get(dataSource);
+    }
+
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+}

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/OctopusJdbcSchema.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/OctopusJdbcSchema.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kr.co.bitnine.octopus.schema.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import kr.co.bitnine.octopus.meta.model.MetaSchema;
+import kr.co.bitnine.octopus.meta.model.MetaTable;
+import kr.co.bitnine.octopus.schema.OctopusDataSource;
+import kr.co.bitnine.octopus.schema.OctopusSchema;
+import org.apache.calcite.schema.Table;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class OctopusJdbcSchema extends OctopusSchema {
+    private static final Log LOG = LogFactory.getLog(OctopusJdbcSchema.class);
+
+    public OctopusJdbcSchema(MetaSchema metaSchema, OctopusDataSource dataSource) {
+        super(metaSchema, dataSource);
+
+        LOG.debug("create OctopusJdbcSchema. schemaName: " + metaSchema.getName());
+
+        ImmutableMap.Builder<String, Table> builder = ImmutableMap.builder();
+        for (MetaTable metaTable : metaSchema.getTables())
+            builder.put(metaTable.getName(), new OctopusJdbcTable(metaTable, this));
+        tableMap = builder.build();
+    }
+}

--- a/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/OctopusJdbcTable.java
+++ b/octopus-core/src/main/java/kr/co/bitnine/octopus/schema/jdbc/OctopusJdbcTable.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kr.co.bitnine.octopus.schema.jdbc;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import kr.co.bitnine.octopus.meta.model.MetaTable;
+import kr.co.bitnine.octopus.schema.OctopusSchema;
+import kr.co.bitnine.octopus.schema.OctopusTable;
+
+import org.apache.calcite.DataContext;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.linq4j.Queryable;
+import org.apache.calcite.linq4j.tree.Primitive;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.runtime.ResultSetEnumerable;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.AbstractTableQueryable;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.pretty.SqlPrettyWriter;
+import org.apache.calcite.sql.util.SqlString;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class OctopusJdbcTable extends OctopusTable
+    implements TranslatableTable, ScannableTable {
+    OctopusJdbcDataSource dataSource;
+    private static final Log LOG = LogFactory.getLog(OctopusJdbcTable.class);
+
+    public OctopusJdbcTable(MetaTable metaTable, OctopusSchema schema) {
+        super(metaTable, schema);
+
+        dataSource = (OctopusJdbcDataSource) schema.getDataSource();
+        LOG.debug("create OctopusJdbcTable. tableName: " + metaTable.getName());
+    }
+
+    public String toString() {
+        return "JdbcTable {" + name + "}";
+    }
+
+    SqlString generateSql() {
+        final SqlNodeList selectList =
+                new SqlNodeList(
+                        Collections.singletonList(
+                                new SqlIdentifier("*", SqlParserPos.ZERO)),
+                        SqlParserPos.ZERO);
+        SqlSelect node =
+                new SqlSelect(SqlParserPos.ZERO, SqlNodeList.EMPTY, selectList,
+                        tableName(), null, null, null, null, null, null, null);
+        final SqlPrettyWriter writer = new SqlPrettyWriter(dataSource.dialect);
+        node.unparse(writer, 0, 0);
+        return writer.toSqlString();
+    }
+
+    SqlIdentifier tableName() {
+        final List<String> strings = new ArrayList<>();
+        strings.add(dataSource.getName());
+        strings.add(schema.getName());
+        strings.add(name);
+        return new SqlIdentifier(strings, SqlParserPos.ZERO);
+    }
+
+    public RelNode toRel(RelOptTable.ToRelContext context,
+                         RelOptTable relOptTable) {
+        return new JdbcTableScan(context.getCluster(), relOptTable, this, dataSource.convention);
+    }
+
+    public <T> Queryable<T> asQueryable(QueryProvider queryProvider,
+                                        SchemaPlus schema, String tableName) {
+        return new JdbcTableQueryable<>(queryProvider, schema, tableName);
+    }
+
+    private List<Pair<Primitive, Integer>> fieldClasses(
+            final JavaTypeFactory typeFactory) {
+        final RelDataType rowType = protoRowType.apply(typeFactory);
+        return Lists.transform(rowType.getFieldList(),
+                new Function<RelDataTypeField, Pair<Primitive, Integer>>() {
+                    public Pair<Primitive, Integer> apply(RelDataTypeField field) {
+                        RelDataType type = field.getType();
+                        Class clazz = (Class) typeFactory.getJavaClass(type);
+                        return Pair.of(Util.first(Primitive.of(clazz), Primitive.OTHER),
+                                type.getSqlTypeName().getJdbcOrdinal());
+                    }
+                });
+    }
+
+    public Enumerable<Object[]> scan(DataContext root) {
+        final JavaTypeFactory typeFactory = root.getTypeFactory();
+        final SqlString sql = generateSql();
+        return ResultSetEnumerable.of(dataSource.getDataSource(), sql.getSql(),
+                JdbcUtils.ObjectArrayRowBuilder.factory(fieldClasses(typeFactory)));
+    }
+
+    private class JdbcTableQueryable<T> extends AbstractTableQueryable<T> {
+        public JdbcTableQueryable(QueryProvider queryProvider, SchemaPlus schema,
+                                  String tableName) {
+            super(queryProvider, schema, OctopusJdbcTable.this, tableName);
+        }
+
+        @Override public String toString() {
+            return "JdbcTableQueryable {table: " + tableName + "}";
+        }
+
+        public Enumerator<T> enumerator() {
+            final JavaTypeFactory typeFactory =
+                    ((CalciteConnection) queryProvider).getTypeFactory();
+            final SqlString sql = generateSql();
+            //noinspection unchecked
+            final Enumerable<T> enumerable = (Enumerable<T>) ResultSetEnumerable.of(
+                    dataSource.getDataSource(), sql.getSql(),
+                    JdbcUtils.ObjectArrayRowBuilder.factory(fieldClasses(typeFactory)));
+            return enumerable.enumerator();
+        }
+    }
+}

--- a/octopus-core/src/test/java/kr/co/bitnine/octopus/frame/SessionServerTest.java
+++ b/octopus-core/src/test/java/kr/co/bitnine/octopus/frame/SessionServerTest.java
@@ -206,6 +206,7 @@ public class SessionServerTest {
         stmt.close();
         conn.close();
         newMemDb.stop();
+        schemaManager.resetDataSourcePool();
     }
 
     @Test
@@ -253,6 +254,7 @@ public class SessionServerTest {
         stmt.close();
         conn.close();
         newMemDb.stop();
+        schemaManager.resetDataSourcePool();
     }
 
     @Test
@@ -289,8 +291,6 @@ public class SessionServerTest {
 
         rows = checkNumRows(stmt, tblName);
         assertEquals(rows, 1);
-
-        dataMemDb.runExecuteUpdate("DROP TABLE \"" + tblName + '"');
 
         stmt.close();
         conn.close();
@@ -469,6 +469,32 @@ public class SessionServerTest {
         pstmt.close();
 
         conn.close();
+    }
+
+    @Test
+    public void testComplexSelect() throws Exception {
+        MemoryDatabase newMemDb = new MemoryDatabase("DATA2");
+        newMemDb.start();
+
+        newMemDb.runExecuteUpdate("CREATE TABLE \"TMP\" (\"ID\" INTEGER, \"NAME\" STRING)");
+
+        Connection conn = getConnection("octopus", "bitnine");
+        Statement stmt = conn.createStatement();
+        stmt.execute("ALTER SYSTEM ADD DATASOURCE \"" + newMemDb.name
+                + "\" CONNECT TO '" + newMemDb.connectionString
+                + "' USING '" + MemoryDatabase.DRIVER_NAME + "'");
+
+        stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery(
+                "SELECT \"EM\".\"id\", \"EM\".\"name\" " +
+                        "FROM \"employee\" \"EM\", " +
+                        "\"DATA2\".\"__DEFAULT\".\"TMP\" \"TM\" " +
+                        "WHERE \"EM\".\"id\" = \"TM\".\"ID\"");
+        rs.close();
+        stmt.close();
+        conn.close();
+        newMemDb.stop();
+        schemaManager.resetDataSourcePool();
     }
 
     @Test

--- a/octopus-core/src/test/resources/log4j.properties
+++ b/octopus-core/src/test/resources/log4j.properties
@@ -17,3 +17,5 @@ log4j.threshold=ALL
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+
+log4j.category.DataNucleus=OFF

--- a/octopus-meta-jdo/src/main/java/kr/co/bitnine/octopus/meta/jdo/model/MDataSource.java
+++ b/octopus-meta-jdo/src/main/java/kr/co/bitnine/octopus/meta/jdo/model/MDataSource.java
@@ -50,6 +50,9 @@ public final class MDataSource implements MetaDataSource {
     @Column(length = MetaConstants.COMMENT_MAX)
     private String comment;
 
+    @Persistent
+    private MetaDataSource.DataSourceType dataSourceType;
+
     @Persistent(mappedBy = "dataSource", dependentElement = "true")
     private Collection<MSchema> schemas;
 
@@ -83,6 +86,15 @@ public final class MDataSource implements MetaDataSource {
 
     public void setComment(String comment) {
         this.comment = comment;
+    }
+
+    @Override
+    public MetaDataSource.DataSourceType getDataSourceType() {
+        return dataSourceType;
+    }
+
+    public void setDataSourceType(MetaDataSource.DataSourceType dataSourceType) {
+        this.dataSourceType = dataSourceType;
     }
 
     @Override

--- a/octopus-meta-jdo/src/test/resources/log4j.properties
+++ b/octopus-meta-jdo/src/test/resources/log4j.properties
@@ -12,8 +12,10 @@
 
 # log4j configuration used during build and unit tests
 
-log4j.rootLogger=INFO,stdout
+log4j.rootLogger=DEBUG,stdout
 log4j.threshold=ALL
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+
+log4j.category.DataNucleus=OFF

--- a/octopus-meta/src/main/java/kr/co/bitnine/octopus/meta/model/MetaDataSource.java
+++ b/octopus-meta/src/main/java/kr/co/bitnine/octopus/meta/model/MetaDataSource.java
@@ -17,6 +17,13 @@ package kr.co.bitnine.octopus.meta.model;
 import java.util.Collection;
 
 public interface MetaDataSource {
+
+    enum DataSourceType {
+        JDBC,
+        CATALOG,
+        METAMODEL
+    }
+
     String getName();
 
     String getDriverName();
@@ -24,6 +31,8 @@ public interface MetaDataSource {
     String getConnectionString();
 
     String getComment();
+
+    DataSourceType getDataSourceType();
 
     Collection<MetaSchema> getSchemas();
 }

--- a/octopus-project/pom.xml
+++ b/octopus-project/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
 
   <properties>
     <hadoop.version>2.6.0</hadoop.version>
-    <calcite.version>1.3.0-incubating</calcite.version>
+    <calcite.version>1.5.0</calcite.version>
     <metamodel.version>4.3.6</metamodel.version>
     <datanucleus.version>4.1.0-release</datanucleus.version>
   </properties>
@@ -196,7 +196,7 @@ limitations under the License.
     </dependencies>
   </dependencyManagement>
 
-  <build>
+  <!--build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -220,5 +220,5 @@ limitations under the License.
         </executions>
       </plugin>
     </plugins>
-  </build>
+  </build-->
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@ limitations under the License.
         </plugin>
 
         <!-- reporting -->
-        <plugin>
+        <!-- plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>2.16</version>
@@ -111,7 +111,7 @@ limitations under the License.
               <version>6.10.1</version>
             </dependency>
           </dependencies>
-        </plugin>
+        </plugin -->
 
         <!-- tools -->
         <plugin>


### PR DESCRIPTION
Basic join implementation using JDBC table.
This uses ResultSetEnumerable in Calcite.
And no plan rules are applied.

There're some known problems.
1) join predicate [STRING] = [INTEGER] not evaluated correctly.
2) Occasionally, connections are not closed in Calcite.
3) Predicate push-downs are not implemented.
